### PR TITLE
Heap

### DIFF
--- a/data-doc/data/scribblings/heap.scrbl
+++ b/data-doc/data/scribblings/heap.scrbl
@@ -42,7 +42,7 @@ See @racket[heap-remove-index!] for how to use @racket[on-update-index].
     (<= (node-val x) (node-val y)))
   (define a-heap-of-nodes (make-heap node<=?))
   a-heap-of-nodes]
-}
+@history[#:changed "7.6.0.17" @elem{Added the @racket[#:on-update-index] optional argument.}]}
 
 @defproc[(heap? [x any/c]) boolean?]{
 
@@ -149,7 +149,7 @@ whereas @racket[heap-remove!] takes O(n) time.
   (heap-add! a-heap a b c) @code:comment{heap now contains a b c}
   (heap-remove-index! a-heap (element-heap-idx b)) @code:comment{b is removed}
   ]
-}
+@history[#:added "7.6.0.17"]}
 
 @defproc[(vector->heap [<=? (-> any/c any/c any/c)]
                        [items vector?]
@@ -169,7 +169,7 @@ See @racket[heap-remove-index!] for how to use @racket[on-update-index].
     (vector (item #\a 17) (item #\b 12) (item #\c 19)))
   (define a-heap (vector->heap item<=? some-sample-items))
 ]
-}
+@history[#:changed "7.6.0.17" @elem{Added the @racket[#:on-update-index] optional argument.}]}
 
 @defproc[(heap->vector [h heap?]) vector?]{
 

--- a/data-lib/data/heap.rkt
+++ b/data-lib/data/heap.rkt
@@ -309,22 +309,3 @@
                  (loop (vt-leftchild i) this)
                  (loop (vt-rightchild i) this))]
            [else #t]))])))
-
-(module+ test
-  (require rackunit)
-  ;; TODO: for a pull request, move this to the test file,
-  ;; and update the docs.
-  ;; Check for all diffs.
-
-  ;; I propose an augmentation of the current heap API to allow
-  ;; for O(log(n)) time removal (instead of O(n)) with a little
-  ;; effort from the user side, but keeping everything backward
-  ;; compatible and equally fast when this feature is not used.
-
-  ;; To that end, I chose to use a callback.
-  ;; (The other option was for the heap to handle heap-nodes, but
-  ;; then heap-min would return a node instead of a value, which
-  ;; would break the API.)
-  
-  ;; Example usage
-  )

--- a/data-lib/data/heap.rkt
+++ b/data-lib/data/heap.rkt
@@ -5,7 +5,7 @@
 
 (define MIN-SIZE 4)
 
-(struct heap ([vec #:mutable] [count #:mutable] <=?))
+(struct heap ([vec #:mutable] [count #:mutable] <=? on-update-index))
 ;; length(vec)/4 <= size <= length(vec), except size >= MIN-SIZE
 ;; size = next available index
 
@@ -26,33 +26,42 @@
 
 ;; Operations
 
-(define (heapify-up <=? vec n)
-  (unless (vt-root? n)
-    (let* ([parent (vt-parent n)]
-           [n-key (vector-ref vec n)]
-           [parent-key (vector-ref vec parent)])
-      (unless (<=? parent-key n-key)
-        (vector-set! vec parent n-key)
-        (vector-set! vec n parent-key)
-        (heapify-up <=? vec parent)))))
+(define (heapify-up <=? vec n on-update-index)
+  (let loop ([n n])
+    (unless (vt-root? n)
+      (let* ([parent (vt-parent n)]
+             [n-key (vector-ref vec n)]
+             [parent-key (vector-ref vec parent)])
+        (unless (<=? parent-key n-key)
+          (vector-set! vec parent n-key)
+          (vector-set! vec n parent-key)
+          (when on-update-index
+            (on-update-index n-key parent)
+            (on-update-index parent-key n))
+          (loop parent))))))
 
-(define (heapify-down <=? vec n size)
-  (let ([left (vt-leftchild n)]
-        [right (vt-rightchild n)]
-        [n-key (vector-ref vec n)])
-    (when (< left size)
-      (let ([left-key (vector-ref vec left)])
-        (let-values ([(child child-key)
-                      (if (< right size)
-                          (let ([right-key (vector-ref vec right)])
-                            (if (<=? left-key right-key)
-                                (values left left-key)
-                                (values right right-key)))
-                          (values left left-key))])
-          (unless (<=? n-key child-key)
-            (vector-set! vec n child-key)
-            (vector-set! vec child n-key)
-            (heapify-down <=? vec child size)))))))
+(define (heapify-down <=? vec n size on-update-index)
+  (let loop ([n n])
+    (let ([left (vt-leftchild n)]
+          [right (vt-rightchild n)]
+          [n-key (vector-ref vec n)])
+      (when (< left size)
+        (let ([left-key (vector-ref vec left)])
+          (let-values ([(child child-key)
+                        (if (< right size)
+                            (let ([right-key (vector-ref vec right)])
+                              (if (<=? left-key right-key)
+                                  (values left left-key)
+                                  (values right right-key)))
+                            (values left left-key))])
+            (unless (<=? n-key child-key)
+              (vector-set! vec n child-key)
+              (vector-set! vec child n-key)
+              (when on-update-index
+                (on-update-index child-key n)
+                (on-update-index n-key child))
+              (loop child)
+              #;(heapify-down <=? vec child size))))))))
 
 (define (subheap? <=? vec n size)
   (let ([left (vt-leftchild n)]
@@ -80,26 +89,28 @@
 
 ;; Heaps
 
-(define (make-heap <=?)
-  (heap (make-vector MIN-SIZE #f) 0 <=?))
+(define (make-heap <=? #:on-update-index [on-update-index #f])
+  (heap (make-vector MIN-SIZE #f) 0 <=? on-update-index))
 
 (define (list->heap <=? lst)
   (vector->heap <=? (list->vector lst)))
 
-(define (vector->heap <=? vec0 [start 0] [end (vector-length vec0)])
+(define (vector->heap <=? vec0
+                      [start 0] [end (vector-length vec0)]
+                      #:on-update-index [on-update-index #f])
   (define size (- end start))
   (define len (let loop ([len MIN-SIZE]) (if (<= size len) len (loop (* 2 len)))))
   (define vec (make-vector len #f))
   ;; size <= length(vec)
   (vector-copy! vec 0 vec0 start end)
   (for ([n (in-range (sub1 size) -1 -1)])
-    (heapify-down <=? vec n size))
-  (heap vec size <=?))
+    (heapify-down <=? vec n size on-update-index))
+  (heap vec size <=? on-update-index))
 
 (define (heap-copy h)
   (match h
-    [(heap vec count <=?)
-     (heap (vector-copy vec) count <=?)]))
+    [(heap vec count <=? on-update-index)
+     (heap (vector-copy vec) count <=? on-update-index)]))
 
 (define (heap-add! h . keys)
   (heap-add-all! h (list->vector keys)))
@@ -114,7 +125,7 @@
                       [(heap? keys)
                        (values (heap-vec keys) (heap-count keys))])])
     (match h
-      [(heap vec size <=?)
+      [(heap vec size <=? on-update-index)
        (let* ([new-size (+ size keys-size)]
               [vec (if (> new-size (vector-length vec))
                        (let ([vec (grow-vector vec new-size)])
@@ -122,27 +133,28 @@
                          vec)
                        vec)])
          (vector-copy! vec size keys 0 keys-size)
-         (for ([n (in-range size new-size)])
-           (heapify-up <=? vec n))
+         (for ([n (in-range size new-size)]
+               [item (in-vector vec size)])
+           (when on-update-index
+             (on-update-index item n))
+           (heapify-up <=? vec n on-update-index))
          (set-heap-count! h new-size))])))
 
 (define (heap-min h)
   (match h
-    [(heap vec size <=?)
+    [(heap vec size <=? on-update-index)
      (when (zero? size)
        (error 'heap-min "empty heap"))
      (vector-ref vec 0)]))
 
 (define (heap-remove-min! h)
-  (match h
-    [(heap vec size <=?)
-     (when (zero? size)
-       (error 'heap-remove-min! "empty heap"))
-     (heap-remove-index! h 0)]))
+  (when (zero? (heap-count h))
+    (error 'heap-remove-min! "empty heap"))
+  (heap-remove-index! h 0))
 
 (define (heap-remove-index! h index)
   (match h
-    [(heap vec size <=?)
+    [(heap vec size <=? on-update-index)
      (unless (< index size)
        (if (zero? size)
            (error 'heap-remove-index!
@@ -150,32 +162,38 @@
            (error 'heap-remove-index!
                   "index out of bounds [0,~s]: ~s" (sub1 size) index)))
      (define sub1-size (sub1 size))
-     (vector-set! vec index (vector-ref vec sub1-size))
+     (define last-item (vector-ref vec sub1-size))
+     (define removed-item (vector-ref vec index))
+     (vector-set! vec index last-item)
      (vector-set! vec sub1-size #f)
+     (when on-update-index
+       (on-update-index last-item index)
+       (on-update-index removed-item #f))
      (cond
        [(= sub1-size index)
         ;; easy to remove the right-most leaf
         (void)]
        [(= index 0)
         ;; can only go down when at the root
-        (heapify-down <=? vec index sub1-size)]
+        (heapify-down <=? vec index sub1-size on-update-index)]
        [else
         (define index-parent (vt-parent index))
         (cond
           ;; if we are in the right relationship with our parent,
           ;; try to heapify down
           [(<=? (vector-ref vec index-parent) (vector-ref vec index))
-           (heapify-down <=? vec index sub1-size)]
+           (heapify-down <=? vec index sub1-size on-update-index)]
           [else
            ;; otherwise we need to heapify up
-           (heapify-up <=? vec index)])])
+           (heapify-up <=? vec index on-update-index)])])
      (when (< MIN-SIZE size (quotient (vector-length vec) 4))
        (set-heap-vec! h (shrink-vector vec)))
      (set-heap-count! h sub1-size)]))
 
+;; Warning: This function can be slow (linear time)
 (define (heap-get-index h v same?)
   (match h
-    [(heap vec size <=?)
+    [(heap vec size <=? on-update-index)
      (and (not (eq? 0 size))
           (let search ([n 0] [n-key (vector-ref vec 0)])
             (cond
@@ -197,10 +215,14 @@
                          (or (search left left-key) (search-right))
                          (search-right))))])))]))
 
+;; Returns whether the removal was successful, that is,
+;; whether v was indeed in the heap.
 (define (heap-remove! h v #:same? [same? equal?])
-  (match (heap-get-index h v same?)
-    [#f (void)]
-    [n (heap-remove-index! h n)]))
+  (define idx (heap-get-index h v same?))
+  (and idx
+       (begin
+         (heap-remove-index! h idx)
+         #t)))
 
 (define (in-heap h)
   (in-heap/consume! (heap-copy h)))
@@ -233,16 +255,16 @@
   (define (>=? x y) (<=? y x))
   (define size (vector-length v))
   (for ([n (in-range (sub1 size) -1 -1)])
-    (heapify-down >=? v n size))
+    (heapify-down >=? v n size #f))
   (for ([last (in-range (sub1 size) 0 -1)])
     (let ([tmp (vector-ref v 0)])
       (vector-set! v 0 (vector-ref v last))
       (vector-set! v last tmp))
-    (heapify-down >=? v 0 last)))
+    (heapify-down >=? v 0 last #f)))
 
 (define (heap->vector h)
   (match h
-    [(heap vec size <=?)
+    [(heap vec size <=? on-update-index)
      (let ([v (vector-copy vec 0 size)])
        (heap-sort!* v <=?)
        v)]))
@@ -250,18 +272,21 @@
 ;; --------
 
 (provide/contract
- [make-heap (-> (and/c (procedure-arity-includes/c 2)
-                       (unconstrained-domain-> any/c))
-                heap?)]
+ [make-heap (->* ((and/c (procedure-arity-includes/c 2)
+                         (unconstrained-domain-> any/c)))
+                 [#:on-update-index (-> any/c (or/c #f exact-nonnegative-integer?) any/c)]
+                 heap?)]
  [heap? (-> any/c boolean?)]
  [heap-count (-> heap? exact-nonnegative-integer?)]
  [heap-add! (->* (heap?) () #:rest list? void?)]
  [heap-add-all! (-> heap? (or/c list? vector? heap?) void?)]
  [heap-min (-> heap? any/c)]
  [heap-remove-min! (-> heap? void?)]
- [heap-remove! (->* (heap? any/c) [#:same? (-> any/c any/c any/c)] void?)]
-
- [vector->heap (-> (-> any/c any/c any/c) vector? heap?)]
+ [heap-remove! (->* (heap? any/c) [#:same? (-> any/c any/c any/c)] boolean?)]
+ [heap-remove-index! (-> heap? exact-nonnegative-integer? void?)]
+ [vector->heap (->* ((-> any/c any/c any/c) vector?)
+                    [#:on-update-index (-> any/c exact-nonnegative-integer? any/c)]
+                    heap?)]
  [heap->vector (-> heap? vector?)]
  [heap-copy (-> heap? heap?)]
 
@@ -274,7 +299,7 @@
   (provide valid-heap?)
   (define (valid-heap? a-heap)
     (match a-heap
-      [(heap vec size <=?)
+      [(heap vec size <=? on-update-index)
        (let loop ([i 0]
                   [parent -inf.0])
          (cond


### PR DESCRIPTION
Rationale: The last operation of the following sequence takes O(n) time.
```racket
(struct stc (val))
(define stc<=? ...)
(define h (make-heap stc<=?))
(define stc1 (stc 1))
(define stc2 (stc 2))
...
(heap-add-all! h stc1 stc2 ...)
(heap-remove! h stc1)
```
But I need it to take only O(log(n)) time.
This is possible if the index of the elements are tracked. Ideally, these indices would be tracked by the library, but that would require the elements to be encapsulated, which either would break backward compatibility, or would likely increase the memory usage by a constant factor and decrease the speed of the main operations by a constant factor, which existing users may be unhappy about.

The current proposal is thus a tradeoff which requires to expose the indices to the users so they can be tracked semi-automatically: this ensures that almost zero time and space are lost if the new feature is not used, while keeping the interface backward compatible, and not requiring much from the user to use the new feature.

The newly exported `heap-remove-index` takes O(log(n)) time, and the index is tracked semi-automatically by using the `#:on-update-index` argument to `make-heap`. Example from the docs:
```racket
(struct element (str [heap-idx #:mutable]) #:transparent)
(define (element<=? e1 e2)
  (string<=? (element-str e1) (element-str e2)))
(define a-heap (make-heap element<=? #:on-update-index set-element-heap-idx!))
(define-values (a b c)
  (values
   (element "a" #f)
   (element "b" #f)
   (element "c" #f)))
(heap-add! a-heap a b c) ; heap now contains a b c
(heap-remove-index! a-heap (element-heap-idx b)) ; b is removed, takes O(log(n)) time
```

Docs are updated, all tests in `data` pass.