### PR TITLE
Cleanup heap

### DIFF
--- a/data-doc/data/scribblings/heap.scrbl
+++ b/data-doc/data/scribblings/heap.scrbl
@@ -110,7 +110,8 @@ empty, an exception is raised.
 }
 
 @defproc[(heap-remove! [h heap?] [v any/c] [#:same? same? (-> any/c any/c any/c) equal?]) boolean?]{
-Removes @racket[v] from the heap @racket[h] if it exists. 
+Removes @racket[v] from the heap @racket[h] if it exists,
+and returns @racket[#t] if the removal was successful, @racket[#f] otherwise.
 @examples[#:eval the-eval
   (define a-heap (make-heap string<=? string=?))
   (heap-add! a-heap "a" "b" "c")

--- a/data-doc/data/scribblings/heap.scrbl
+++ b/data-doc/data/scribblings/heap.scrbl
@@ -109,14 +109,14 @@ empty, an exception is raised.
   (heap-min a-heap)]
 }
 
-@defproc[(heap-remove! [h heap?] [v any/c] [#:same? same? (-> any/c any/c any/c) equal?]) void?]{
+@defproc[(heap-remove! [h heap?] [v any/c] [#:same? same? (-> any/c any/c any/c) equal?]) boolean?]{
 Removes @racket[v] from the heap @racket[h] if it exists. 
 @examples[#:eval the-eval
   (define a-heap (make-heap string<=? string=?))
   (heap-add! a-heap "a" "b" "c")
   (heap-remove! a-heap "b")
   (for/list ([a (in-heap a-heap)]) a)]
-}
+@history[#:changed "7.6.0.18" @elem{Returns a @racket[boolean?] instead of @racket[void?]}]}
 
 @defproc[(vector->heap [<=? (-> any/c any/c any/c)] [items vector?]) heap?]{
 

--- a/data-test/tests/data/heap.rkt
+++ b/data-test/tests/data/heap.rkt
@@ -3,6 +3,11 @@
          data/heap
          (submod data/heap test-util))
 
+;; Check growth rate of the vectors
+(for ([n (in-range 10000)])
+  (check <= n (fittest-block-size n))
+  (check <= (fittest-block-size n) (max MIN-SIZE (* 2 n))))
+
 (define (mkheap) (vector->heap <= (vector 6 2 4 10 8)))
 
 (test-equal? "heap->vector"


### PR DESCRIPTION
Before the bigger changes, I wanted to cleanup the code and also avoid some unnecessary operations (pulling some `vector-set!`s and `vector-ref`s out of the loops in `heapify-up` and `heapify-down`). The performance impact is not large (about 5-10% speedup) but it will have a higher impact with encapsulation.

Shrinking and growing are now also a little cleaner by relying on a single growth function `fittest-block-size` instead of ad-hoc codes and (small) loops. Some tests are added to check that this function is well-behaved.

As agreed before with Sam on slack, this also changes the return value of `heap-remove!` to `boolean?` instead of `void?`.