### PR TITLE
fix typo in gvector docs

### DIFF
--- a/data-doc/data/scribblings/gvector.scrbl
+++ b/data-doc/data/scribblings/gvector.scrbl
@@ -132,7 +132,7 @@ elements of @racket[gv] in order.
 }
 
 @defproc[(list->gvector [l list?])
-         gvector?]
+         gvector?]{
 Returns a gvector of length @racket[(length l)] containint the
 elements of @racket[l] in order.
 }


### PR DESCRIPTION
Not a very heroic change, but fixes an out of place right curly brace.