### PR TITLE
Fix typo in bit-vector-copy docs

### DIFF
--- a/data-doc/data/scribblings/bit-vector.scrbl
+++ b/data-doc/data/scribblings/bit-vector.scrbl
@@ -70,7 +70,7 @@ invoked if it is a procedure, returned otherwise.
 @defproc[(bit-vector-set! 
           [bv bit-vector?]
           [index (and/c exact-nonnegative-integer? 
-                        (</c (+ 1 (bit-vector-length vv))))]
+                        (</c (+ 1 (bit-vector-length bv))))]
           [value boolean?])
          void?]{
 
@@ -101,7 +101,7 @@ Returns the number of set bits in the bit-vector @racket[bv].
 
 @defproc[(bit-vector-copy [bv bit-vector?]
                           [start exact-nonnegative-integer? 0]
-                          [end exact-nonnegative-integer? (bit-vector-length v)])
+                          [end exact-nonnegative-integer? (bit-vector-length bv)])
          bit-vector?]{
 
 Creates a fresh bit-vector with the

--- a/data-doc/data/scribblings/bit-vector.scrbl
+++ b/data-doc/data/scribblings/bit-vector.scrbl
@@ -101,7 +101,7 @@ Returns the number of set bits in the bit-vector @racket[bv].
 
 @defproc[(bit-vector-copy [bv bit-vector?]
                           [start exact-nonnegative-integer? 0]
-                          [end exact-nonnegative-integer? (vector-length v)])
+                          [end exact-nonnegative-integer? (bit-vector-length v)])
          bit-vector?]{
 
 Creates a fresh bit-vector with the


### PR DESCRIPTION
Should be bit-vector-length not vector-length