### PR TITLE
Make splay-tree->list handle non-numeric keys.

### DIFF
--- a/data-lib/data/splay-tree.rkt
+++ b/data-lib/data/splay-tree.rkt
@@ -475,14 +475,12 @@ Options
 (define (splay-tree->list s)
   (match s
     [(splay-tree root size cmp adjust?)
-     (let loop ([x root] [onto null] [k* 0])
+     (let loop ([x root] [onto null])
        (match x
          [(node key value left right)
-          (let ([key (+ key k*)])
-            (loop left
-                  (cons (cons key value)
-                        (loop right onto key))
-                  key))]
+          (loop left
+                (cons (cons key value)
+                      (loop right onto)))]
          [#f onto]))]))
 
 ;; ------------------------------------------------------------


### PR DESCRIPTION
The current splay-tree->list doesn't handle non-numeric keys due to the expression `(+ key k*)`. This PR simply removes the `k*` variable.

A test case that shows the bug:

```
#lang racket
(require data/order data/splay-tree)
(define string-order (order 'string-order string? string=? string<?))
(define S (make-splay-tree string-order))
(splay-tree-set! S "foo" 1)
(splay-tree-set! S "bar" 2)
(splay-tree->list S)
```