### PR TITLE
Handle non-adjustable trees in splay-tree->list

### DIFF
--- a/data-lib/data/splay-tree.rkt
+++ b/data-lib/data/splay-tree.rkt
@@ -478,7 +478,7 @@ Options
      (let loop ([x root] [onto null] [k* 0])
        (match x
          [(node key value left right)
-          (let ([key (+ key k*)])
+          (let ([key (if adjust? (+ key k*) key)])
             (loop left
                   (cons (cons key value)
                         (loop right onto key))


### PR DESCRIPTION
Tests

(define s (make-adjustable-splay-tree))
(splay-tree-set! s 1 'a)
(splay-tree-set! s 2 'b)
(splay-tree-set! s 3 'c)
(splay-tree->list s)

(define t (make-splay-tree))
(splay-tree-set! t 1 'a)
(splay-tree-set! t 2 'b)
(splay-tree-set! t 3 'c)
(splay-tree->list t)

