### PR TITLE
Revise for better performance.

### DIFF
--- a/data-lib/data/gvector.rkt
+++ b/data-lib/data/gvector.rkt
@@ -1,18 +1,77 @@
 #lang racket/base
 ;; written by ryanc
+
+;; Memory-safety invariant:
+;;
+;; For every gvector gv, at every observable point in time:
+;;   (<= (gvector-n gv) (vector-length (gvector-vec gv)))
+;;
+;; This data structure is NOT thread-safe: concurrent mutation may
+;; lose updates or produce incorrect results. However, the invariant
+;; above ensures that concurrent access cannot cause memory-safety
+;; violations (out-of-bounds reads via unsafe-vector*-ref).
+;;
+;; The invariant is maintained by ordering field updates and using CAS:
+;;
+;; - Growing (gvector-add!, gvector-insert!, gvector-append!):
+;;   Update vec first (to a larger vector), then update n.
+;;   Any concurrent reader sees the old (smaller) n with the new
+;;   (larger) vec, so the invariant holds.
+;;
+;; - Shrinking (gvector-remove! + trim!):
+;;   Update n first (to a smaller value), then update vec.
+;;   Any concurrent reader sees the new (smaller) n with the old
+;;   (larger) vec, so the invariant holds.
+;;
+;; - CAS on vec (unsafe-struct*-cas! gv 0 old-vec new-vec):
+;;   When growing, define/ensure-space! uses CAS to install the new
+;;   vector. If another thread replaced vec concurrently (e.g. two
+;;   concurrent gvector-add! calls both creating new vectors), the
+;;   CAS fails and the operation retries with the current vec.
+;;   Without CAS, thread T1 could install a small vector while T2
+;;   installs a large n, violating the invariant.
+;;   Similarly, trim! uses CAS when installing a smaller vector.
+;;
+;; - n re-read in trim!:
+;;   trim! re-reads n before creating the smaller vector. If n has
+;;   grown past the target capacity (from concurrent adds that didn't
+;;   need to resize vec), trim! aborts. After CAS succeeds, trim!
+;;   checks again and grows back via ensure-free-space! if needed.
 (require (for-syntax racket/base
                      syntax/contract
                      syntax/for-body)
+	 racket/performance-hint
          racket/serialize
+         racket/fixnum
          racket/contract/base
          racket/dict
+	 racket/unsafe/ops
          racket/vector
          racket/struct)
 
+;; When the environment variable GVECTOR_SLEEP is set at compile time,
+;; (maybe-sleep tag) expands to (sleep 0.01), widening the race window
+;; at the specified point so stress tests can exercise CAS retry paths.
+;; GVECTOR_SLEEP=1 activates all sleep points; GVECTOR_SLEEP=tag
+;; activates only the matching point. When unset, expands to (void).
+(define-syntax (maybe-sleep stx)
+  (syntax-case stx ()
+    [(_ tag)
+     (let ([env (getenv "GVECTOR_SLEEP")])
+       (if (and env
+                (or (equal? env "1")
+                    (equal? env (symbol->string (syntax-e #'tag)))))
+           #'(sleep 0.01)
+           #'(void)))]))
+
 (define DEFAULT-CAPACITY 10)
 
+(define MIN-CAPACITY 8)
+
 (define (make-gvector #:capacity [capacity DEFAULT-CAPACITY])
-  (gvector (make-vector capacity #f) 0))
+  (unless (exact-nonnegative-integer? capacity)
+    (raise-argument-error* 'make-gvector 'data/gvector "exact-nonnegative-integer?" capacity))
+  (gvector (make-vector (max capacity MIN-CAPACITY) 0) 0))
 
 (define gvector*
   (let ([gvector
@@ -29,45 +88,86 @@
   (unless (< index hi)
     (raise-range-error who "gvector" "" index gv 0 (sub1 hi))))
 
-;; ensure-free-space! : GVector Nat -> Void
-(define (ensure-free-space! gv needed-free-space)
-  (define vec (gvector-vec gv))
-  (define n (gvector-n gv))
-  (define cap (vector-length vec))
-  (define needed-cap (+ n needed-free-space))
-  (unless (<= needed-cap cap)
-    (define new-cap
-      (let loop ([new-cap (max DEFAULT-CAPACITY cap)])
-        (if (<= needed-cap new-cap) new-cap (loop (* 2 new-cap)))))
-    (define new-vec (make-vector new-cap #f))
-    (vector-copy! new-vec 0 vec)
-    (set-gvector-vec! gv new-vec)))
+(begin-encourage-inline
 
-(define gvector-add!
-  (case-lambda
-    [(gv item)
-     (ensure-free-space! gv 1)
-     (define n (gvector-n gv))
-     (define v (gvector-vec gv))
-     (vector-set! v n item)
-     (set-gvector-n! gv (add1 n))]
-    [(gv . items)
-     (define item-count (length items))
-     (ensure-free-space! gv item-count)
-     (define n (gvector-n gv))
-     (define v (gvector-vec gv))
-     (for ([index (in-naturals n)] [item (in-list items)])
-       (vector-set! v index item))
-     (set-gvector-n! gv (+ n item-count))]))
+  (define (check-gvector who gv)
+    (unless (gvector? gv)
+      (raise-argument-error* who 'data/gvector "gvector?" gv)))
+
+
+  ;; grow-vec : Vector Nat Nat -> Vector/#f
+  ;; Returns a new, larger vector if more space is needed, or #f if
+  ;; the existing vector has enough capacity.
+  (define (grow-vec vec n needed-free-space)
+    (define cap (unsafe-vector*-length vec))
+    (define needed-cap (unsafe-fx+ n needed-free-space))
+    (cond [(<= needed-cap cap) #f]
+	  [else
+	   ;; taken from Rust's raw_vec implementation
+	   (let* ([new-cap (unsafe-fxmax (unsafe-fx* 2 cap) needed-cap)]
+		  [new-cap (unsafe-fxmax new-cap MIN-CAPACITY)])
+	     (vector*-extend vec new-cap 0))]))
+
+  ;; ensure-free-space! : GVector Nat -> Void
+  ;; Ensures the gvector's vec has room for needed-free-space more
+  ;; elements beyond the current n. Uses CAS to install the new vector
+  ;; so that concurrent growers don't clobber each other.
+  (define (ensure-free-space! gv needed-free-space)
+    (let loop ()
+      (define v (gvector-vec gv))
+      (maybe-sleep ensure-space) ; widen window for concurrent growers
+      (define new-v (grow-vec v (gvector-n gv) needed-free-space))
+      (when new-v
+	;; CAS: only install if vec hasn't been replaced by another thread.
+	;; If CAS fails, another thread installed a different vec; retry
+	;; to check if the new vec is big enough.
+	(unless (unsafe-struct*-cas! gv 0 v new-v)
+	  (loop)))))
+
+  ;; define/ensure-space! : binds n and v after ensuring the gvector
+  ;; has room. Uses CAS on vec so concurrent ensure-space! calls
+  ;; don't clobber each other.
+  (define-syntax-rule (define/ensure-space! (n v) gv needed-free-space)
+    (begin (define n (gvector-n gv))
+	   (define v
+	     (let loop ([v1 (gvector-vec gv)])
+	       (maybe-sleep ensure-space) ; widen window for concurrent growers
+	       (define v2 (grow-vec v1 n needed-free-space))
+	       (cond [(not v2) v1]   ; already big enough
+		     ;; CAS: install new vec, retry if another thread changed it
+		     [(unsafe-struct*-cas! gv 0 v1 v2) v2]
+		     [else (loop (gvector-vec gv))])))))
+
+  ;; only safe on unchaperoned gvectors
+  (define (unsafe-gvector-add! gv item)
+    (define/ensure-space! (n v) gv 1)
+    (unsafe-vector*-set! v n item)
+    ;; Invariant (1): vec is already large enough (set by define/ensure-space!),
+    ;; so updating n maintains n <= vector-length(vec).
+    (set-gvector-n! gv (unsafe-fx+ 1 n)))
+
+  (define gvector-add!
+    (case-lambda
+      [(gv item)
+       (check-gvector 'gvector-add! gv)
+       (define/ensure-space! (n v) gv 1)
+       (unsafe-vector*-set! v n item)
+       (set-gvector-n! gv (unsafe-fx+ 1 n))]
+      [(gv . items)
+       (check-gvector 'gvector-add! gv)
+       (define item-count (length items))
+       (define/ensure-space! (n v) gv item-count)
+       (for ([index (in-naturals n)] [item (in-list items)])
+	 (unsafe-vector*-set! v index item))
+       (set-gvector-n! gv (+ n item-count))])))
 
 ;; SLOW!
 (define (gvector-insert! gv index item)
   ;; This does (n - index) redundant copies on resize, but that
   ;; happens rarely and I prefer the simpler code.
-  (define n (gvector-n gv))
+  (check-gvector 'gvector-insert! gv)
   (check-index 'gvector-insert! gv index #t)
-  (ensure-free-space! gv 1)
-  (define v (gvector-vec gv))
+  (define/ensure-space! (n v) gv 1)
   (vector-copy! v (add1 index) v index n)
   (vector-set! v index item)
   (set-gvector-n! gv (add1 n)))
@@ -81,22 +181,39 @@
 (define SHRINK-BY-FACTOR 2)
 
 (define (trim! gv)
-  (define n (gvector-n gv))
-  (define v (gvector-vec gv))
-  (define cap (vector-length v))
-  (define new-cap
-    (let loop ([new-cap cap])
-      (cond [(and (>= new-cap (* SHRINK-ON-FACTOR n))
-                  (>= (quotient new-cap SHRINK-BY-FACTOR) SHRINK-MIN))
-             (loop (quotient new-cap SHRINK-BY-FACTOR))]
-            [else new-cap])))
-  (when (< new-cap cap)
-    (define new-v (make-vector new-cap #f))
-    (vector-copy! new-v 0 v 0 n)
-    (set-gvector-vec! gv new-v)))
+  ;; Invariant (1): n has already been decremented before calling trim!,
+  ;; so installing a smaller vec maintains n <= vector-length(vec),
+  ;; provided n hasn't grown since we read it. We re-read n before
+  ;; creating the new vec to abort if concurrent adds have grown n past
+  ;; our target capacity. After CAS, we verify the invariant and grow
+  ;; back if a concurrent add slipped through.
+  (let loop ()
+    (define n0 (gvector-n gv))
+    (define v (gvector-vec gv))
+    (maybe-sleep trim) ; widen window for concurrent add/trim
+    (define cap (vector-length v))
+    (define new-cap
+      (let shrink ([new-cap cap])
+	(cond [(and (>= new-cap (* SHRINK-ON-FACTOR n0))
+		    (>= (quotient new-cap SHRINK-BY-FACTOR) SHRINK-MIN))
+	       (shrink (quotient new-cap SHRINK-BY-FACTOR))]
+	      [else new-cap])))
+    (when (< new-cap cap)
+      ;; Re-read n: if concurrent adds grew n past new-cap, abort.
+      (define n (gvector-n gv))
+      (when (<= n new-cap)
+	(define new-v (make-vector new-cap #f))
+	(vector-copy! new-v 0 v 0 n)
+	;; CAS: only install smaller vec if no other thread replaced vec
+	(when (unsafe-struct*-cas! gv 0 v new-v)
+	  ;; Safety net: if a concurrent add pushed n past new-cap
+	  ;; between our re-read and the CAS, grow back immediately.
+	  (when (> (gvector-n gv) new-cap)
+	    (ensure-free-space! gv 0)))))))
 
 ;; SLOW!
 (define (gvector-remove! gv index)
+  (check-gvector 'gvector-remove! gv)
   (define n (gvector-n gv))
   (define v (gvector-vec gv))
   (check-index 'gvector-remove! gv index #f)
@@ -106,6 +223,7 @@
   (trim! gv))
 
 (define (gvector-remove-last! gv)
+  (check-gvector 'gvector-remove-last! gv)
   (let ([n (gvector-n gv)]
         [v (gvector-vec gv)])
     (unless (> n 0) (error 'gvector-remove-last! "empty"))
@@ -114,45 +232,77 @@
     last-val))
 
 (define (gvector-count gv)
+  (check-gvector 'gvector-count gv)
   (gvector-n gv))
 
 (define none (gensym 'none))
 
 (define (gvector-ref gv index [default none])
+  (check-gvector 'gvector-ref gv)
   (unless (exact-nonnegative-integer? index)
     (raise-type-error 'gvector-ref "exact nonnegative integer" index))
-  (if (< index (gvector-n gv))
-      (vector-ref (gvector-vec gv) index)
-      (cond [(eq? default none)
-             (check-index 'gvector-ref gv index #f)]
-            [(procedure? default) (default)]
-            [else default])))
+  (let ([v (gvector-vec gv)])
+    (maybe-sleep ref) ; widen window for concurrent remove/trim
+    (if (< index (gvector-n gv))
+        (unsafe-vector*-ref v index)
+        (cond [(eq? default none)
+               (check-index 'gvector-ref gv index #f)]
+              [(procedure? default) (default)]
+              [else default]))))
+
+(define (gvector-append! gv gv*)
+  (check-gvector 'gvector-append! gv)
+  (check-gvector 'gvector-append! gv*)
+  (define n* (gvector-n gv*))
+  (define/ensure-space! (n v) gv n*)
+  (vector-copy! v n (gvector-vec gv*) 0 n*)
+  (set-gvector-n! gv (+ n n*)))
+
+(define (gvector-append gv gv*)
+  (check-gvector 'gvector-append gv)
+  (check-gvector 'gvector-append gv*)
+  ;; retain the spare capacity of gv*
+  (define gv0 (make-gvector #:capacity (+ (gvector-n gv) (vector-length (gvector-vec gv*)))))
+  (define v0 (gvector-vec gv0))
+  (vector-copy! v0 0 (gvector-vec gv) 0 (gvector-n gv))
+  (vector-copy! v0 (gvector-n gv) (gvector-vec gv*) (gvector-n gv*)))
+
 
 ;; gvector-set! with index = |gv| is interpreted as gvector-add!
 (define (gvector-set! gv index item)
-  (let ([n (gvector-n gv)])
+  (check-gvector 'gvector-set! gv)
+  (let ([v (gvector-vec gv)]
+        [n (gvector-n gv)])
     (check-index 'gvector-set! gv index #t)
-    (if (= index n)
-        (gvector-add! gv item)
-        (vector-set! (gvector-vec gv) index item))))
+    (if (unsafe-fx= index n)
+        (if (impersonator? gv)
+            (gvector-add! gv item)
+            (unsafe-gvector-add! gv item))
+        (unsafe-vector*-set! v index item))))
 
 ;; creates a snapshot vector
 (define (gvector->vector gv)
-  (vector-copy (gvector-vec gv) 0 (gvector-n gv)))
+  (check-gvector 'gvector->vector gv)
+  (vector*-copy (gvector-vec gv) 0 (gvector-n gv)))
 
 (define (gvector->list gv)
+  (check-gvector 'gvector->list gv)
   (vector->list (gvector->vector gv)))
 
 ;; constructs a gvector
 (define (vector->gvector v)
+  (unless (vector? v)
+    (raise-argument-error* vector->gvector 'data/gvector "vector?" v))
   (define lv (vector-length v))
-  (define gv (make-gvector #:capacity lv))
+  (define gv (make-gvector #:capacity (max lv DEFAULT-CAPACITY)))
   (define nv (gvector-vec gv))
   (vector-copy! nv 0 v)
   (set-gvector-n! gv lv)
   gv)
 
 (define (list->gvector v)
+  (unless (list? v)
+    (raise-argument-error* list->gvector 'data/gvector "list?" v))
   (vector->gvector (list->vector v)))
 
 ;; Iteration methods
@@ -165,8 +315,8 @@
 (define (gvector-iterate-next gv iter)
   (check-index 'gvector-iterate-next gv iter #f)
   (let ([n (gvector-n gv)])
-    (and (< (add1 iter) n)
-         (add1 iter))))
+    (and (< (unsafe-fx+ 1 iter) n)
+         (unsafe-fx+ 1 iter))))
 
 (define (gvector-iterate-key gv iter)
   (check-index 'gvector-iterate-key gv iter #f)
@@ -177,8 +327,7 @@
   (gvector-ref gv iter))
 
 (define (in-gvector gv)
-  (unless (gvector? gv)
-    (raise-type-error 'in-gvector "gvector" gv))
+  (check-gvector 'in-gvector gv)
   (in-dict-values gv))
 
 (define-sequence-syntax in-gvector*
@@ -192,11 +341,11 @@
             (:do-in ([(gv) gv-expr-c])
                     (void) ;; outer-check; handled by contract
                     ([index 0] [vec (gvector-vec gv)] [n (gvector-n gv)]) ;; loop bindings
-                    (< index n) ;; pos-guard
-                    ([(var) (vector-ref vec index)]) ;; inner bindings
+                    (unsafe-fx< index n) ;; pos-guard
+                    ([(var) (unsafe-vector*-ref vec index)]) ;; inner bindings
                     #t ;; pre-guard
                     #t ;; post-guard
-                    ((add1 index) (gvector-vec gv) (gvector-n gv)))]))]
+                    ((unsafe-fx+ 1 index) vec n))]))]
       [[(var ...) (in-gv gv-expr)]
        (with-syntax ([gv-expr-c (wrap-expr/c #'gvector? #'gv-expr #:macro #'in-gv)])
          (syntax/loc stx
@@ -206,25 +355,34 @@
 (define-syntax (for/gvector stx)
   (syntax-case stx ()
     [(_ (clause ...) . body)
+     #'(for/gvector #:capacity DEFAULT-CAPACITY (clause ...) . body)]
+    [(_ #:capacity cap (clause ...) . body)
      (with-syntax ([((pre-body ...) post-body) (split-for-body stx #'body)])
        (quasisyntax/loc stx
-         (let ([gv (make-gvector)])
+         (let ([gv (make-gvector #:capacity cap)])
            (for/fold/derived #,stx () (clause ...)
             pre-body ...
-            (call-with-values (lambda () . post-body)
-              (lambda args (apply gvector-add! gv args) (values))))
+	     (call-with-values (lambda () . post-body)
+			       (case-lambda
+				 [(one) (unsafe-gvector-add! gv one)]
+				 [args (apply gvector-add! gv args)]))
+	     (values))
            gv)))]))
 
 (define-syntax (for*/gvector stx)
   (syntax-case stx ()
     [(_ (clause ...) . body)
+     #'(for/gvector #:capacity DEFAULT-CAPACITY (clause ...) . body)]
+    [(_ #:capacity cap (clause ...) . body)
      (with-syntax ([((pre-body ...) post-body) (split-for-body stx #'body)])
        (quasisyntax/loc stx
-         (let ([gv (make-gvector)])
+         (let ([gv (make-gvector #:capacity cap)])
            (for*/fold/derived #,stx () (clause ...)
             pre-body ...
             (call-with-values (lambda () . post-body)
-              (lambda args (apply gvector-add! gv args) (values))))
+                              (case-lambda
+                                [(one) (begin (unsafe-gvector-add! gv one) (values))]
+                                [args (begin (apply gvector-add! gv args) (values))])))
            gv)))]))
 
 (struct gvector (vec n)
@@ -276,39 +434,26 @@
    #t
    (or (current-load-relative-directory) (current-directory))))
 
-(provide/contract
- [gvector?
-  (-> any/c any)]
- [rename gvector* gvector
-  (->* () () #:rest any/c gvector?)]
- [make-gvector
-  (->* () (#:capacity exact-positive-integer?) gvector?)]
- [gvector-ref
-  (->* (gvector? exact-nonnegative-integer?) (any/c) any)]
- [gvector-set!
-  (-> gvector? exact-nonnegative-integer? any/c any)]
- [gvector-add!
-  (->* (gvector?) () #:rest any/c any)]
- [gvector-insert!
-  (-> gvector? exact-nonnegative-integer? any/c any)]
- [gvector-remove!
-  (-> gvector? exact-nonnegative-integer? any)]
- [gvector-remove-last!
-  (-> gvector? any)]
- [gvector-count
-  (-> gvector? any)]
- [gvector->vector
-  (-> gvector? vector?)]
- [gvector->list
-  (-> gvector? list?)]
- [vector->gvector
-  (-> vector? gvector?)]
- [list->gvector
-  (-> list? gvector?)])
-
-(provide (rename-out [in-gvector* in-gvector])
-         for/gvector
-         for*/gvector)
+(provide
+ gvector?
+ (rename-out [gvector* gvector])
+ make-gvector
+ gvector-ref
+ gvector-set!
+ gvector-add!
+ gvector-insert!
+ gvector-remove!
+ gvector-remove-last!
+ gvector-append
+ gvector-append!
+ gvector-count
+ gvector->vector
+ gvector->list
+ vector->gvector
+ list->gvector
+ (rename-out [in-gvector* in-gvector])
+ for/gvector
+ for*/gvector)
 
 (module+ deserialize
   (provide deserialize-gvector)

--- a/data-lib/info.rkt
+++ b/data-lib/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection 'multi)
-(define deps '(("base" #:version "6.2.900.6")))
+(define deps '(("base" #:version "8.12.0.10")))
 (define build-deps '("rackunit-lib"))
 
 (define pkg-desc "implementation (no documentation) part of \"data\"")

--- a/data-test/tests/data/gvector-sleep-stress.rkt
+++ b/data-test/tests/data/gvector-sleep-stress.rkt
@@ -1,0 +1,194 @@
+#lang racket/base
+;; Stress tests that recompile data/gvector with GVECTOR_SLEEP set to
+;; widen specific race windows. Each test activates only the sleep
+;; point relevant to the invariant it tests, so other operations
+;; remain fast. The gvector module is loaded via dynamic-require with
+;; compiled file loading disabled, so the sleep-enabled version is
+;; never cached.
+
+(require rackunit
+         racket/unsafe/ops)
+
+(define (make-gvector-ns tag)
+  ;; Set GVECTOR_SLEEP to the tag so only the matching maybe-sleep
+  ;; expands to (sleep 0.01). Load in a fresh namespace with compiled
+  ;; files disabled. Returns a lookup function for that namespace.
+  (putenv "GVECTOR_SLEEP" tag)
+  (define ns (make-base-namespace))
+  (parameterize ([use-compiled-file-paths '()]
+		 [current-namespace ns])
+    (dynamic-require 'data/gvector #f))
+  (putenv "GVECTOR_SLEEP" "")
+  (lambda (sym)
+    (parameterize ([use-compiled-file-paths '()]
+		   [current-namespace ns])
+      (dynamic-require 'data/gvector sym))))
+
+(define ref-ns (make-gvector-ns "ref"))
+(define trim-ns (make-gvector-ns "trim"))
+(define es-ns (make-gvector-ns "ensure-space"))
+
+;; Test 1: vec-before-n ordering in gvector-ref.
+;; Only gvector-ref sleeps (tag "ref"); removes run at full speed.
+;; A reader reads vec, sleeps 10ms, then reads n. During the sleep,
+;; many concurrent removes can decrement n and trigger trim! which
+;; replaces vec with a shorter one. With correct vec-before-n ordering,
+;; the reader holds the old (large) vec and reads the new (small) n —
+;; safe. With wrong n-before-vec ordering, the reader reads the old
+;; (large) n and the new (small) vec — out of bounds.
+(test-case "sleep-stress: ref + remove (vec-before-n ordering)"
+  (define make-gvector* (ref-ns 'make-gvector))
+  (define gvector-add!* (ref-ns 'gvector-add!))
+  (define gvector-ref* (ref-ns 'gvector-ref))
+  (define gvector-count* (ref-ns 'gvector-count))
+  (define gvector-remove-last!* (ref-ns 'gvector-remove-last!))
+  (for ([iter (in-range 5)])
+    (define gv (make-gvector*))
+    ;; Fill with enough elements that removing triggers trim!
+    ;; trim! fires when cap >= 4*n, so starting at n=1000 with
+    ;; cap=1024, after 744 removes n=256 and cap=1024 >= 4*256,
+    ;; so trim! shrinks to 512. Further removes trigger more shrinks.
+    (for ([i 1000])
+      (gvector-add!* gv i))
+    (define pool (make-parallel-thread-pool 4))
+    (define stop? #f)
+    (define found-garbage? #f)
+    ;; Readers that access near the end of the gvector.
+    ;; Each ref takes ~10ms due to the sleep.
+    ;; Check that returned values are valid (fixnums 0-999 or #f).
+    (define readers
+      (for/list ([t (in-range 2)])
+        (thread #:pool pool
+                (lambda ()
+                  (let loop ()
+                    (define n (gvector-count* gv))
+                    (when (> n 0)
+                      (define val (gvector-ref* gv (sub1 n) #f))
+                      (when (and val (not (and (fixnum? val) (<= 0 val 999))))
+                        (set! found-garbage? #t)))
+                    (unless stop?
+                      (loop)))))))
+    ;; Removers run at full speed (no sleep in remove/trim)
+    (define removers
+      (for/list ([t (in-range 2)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([_ (in-range 400)])
+                    (with-handlers ([exn:fail? void])
+                      (gvector-remove-last!* gv)))))))
+    (for-each thread-wait removers)
+    (set! stop? #t)
+    (parallel-thread-pool-close pool)
+    (for-each thread-wait readers)
+    (check-false found-garbage?
+                 (format "iter ~a: read garbage from beyond vector bounds" iter))))
+
+;; Test 2: trim! under concurrent add pressure.
+;; Only trim! sleeps (tag "trim"); adds run at full speed.
+;; Exercises two protections in trim!:
+;; (a) CAS on vec: if a grower installed a larger vec during the sleep,
+;;     CAS fails and trim! retries rather than clobbering.
+;; (b) n re-read: if concurrent adds grew n past the target capacity
+;;     without changing vec (because it had room), trim! aborts.
+;; The invariant violation (n > vector-length(vec)) is transient and
+;; hard to observe because adds immediately re-grow, so the test
+;; primarily verifies no crashes or memory errors occur.
+(test-case "sleep-stress: add + remove (trim! CAS)"
+  (define make-gvector* (trim-ns 'make-gvector))
+  (define gvector-add!* (trim-ns 'gvector-add!))
+  (define gvector-ref* (trim-ns 'gvector-ref))
+  (define gvector-count* (trim-ns 'gvector-count))
+  (define gvector-remove-last!* (trim-ns 'gvector-remove-last!))
+  (for ([iter (in-range 5)])
+    (define gv (make-gvector*))
+    ;; Start with enough elements that removing triggers trim!
+    ;; n=1000, cap=1024. After ~744 removes, cap >= 4*n triggers shrink.
+    (for ([i 1000])
+      (gvector-add!* gv i))
+    (define pool (make-parallel-thread-pool 6))
+    (define stop? #f)
+    (define found-garbage? #f)
+    ;; Writers add continuously so they're active during trim!'s sleep.
+    ;; Each trim! sleeps 10ms; writers must be adding during that window
+    ;; so they push n past trim!'s target capacity.
+    (define writers
+      (for/list ([t (in-range 2)])
+        (thread #:pool pool
+                (lambda ()
+                  (let loop ()
+                    (with-handlers ([exn:fail? void])
+                      (gvector-add!* gv 42))
+                    (unless stop?
+                      (loop)))))))
+    ;; Checkers continuously verify n <= vector-length(vec) directly.
+    ;; gvector-ref can't detect this because vec-before-n ordering
+    ;; makes it safe even when the invariant is transiently violated.
+    ;; We read the struct fields directly via unsafe-struct*-ref
+    ;; (vec=field 0, n=field 1) to observe the transient violation.
+    (define readers
+      (for/list ([t (in-range 2)])
+        (thread #:pool pool
+                (lambda ()
+                  (let loop ()
+                    ;; Read vec first, then n. If trim! just installed
+                    ;; a small vec and n is still large from adds,
+                    ;; we see v=small, n=large => violation.
+                    (define v (unsafe-struct*-ref gv 0))
+                    (define n (unsafe-struct*-ref gv 1))
+                    (when (> n (vector-length v))
+                      (set! found-garbage? #t))
+                    (unless stop?
+                      (loop)))))))
+    ;; Removers trigger trim! which sleeps between reading vec and CAS
+    (define removers
+      (for/list ([t (in-range 2)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([_ (in-range 400)])
+                    (with-handlers ([exn:fail? void])
+                      (gvector-remove-last!* gv)))))))
+    (for-each thread-wait removers)
+    (set! stop? #t)
+    (for-each thread-wait writers)
+    (for-each thread-wait readers)
+    (parallel-thread-pool-close pool)
+    (check-false found-garbage?
+                 (format "iter ~a: read garbage from beyond vector bounds" iter))))
+
+;; Test 3: CAS in define/ensure-space!.
+;; Only ensure-space! sleeps (tag "ensure-space"); other ops fast.
+;; Two growers both read the same vec, sleep 10ms, then both try to
+;; create and install new vectors. With CAS, only one succeeds and
+;; the other retries. Without CAS, both install and the last writer
+;; wins — which may be the thread creating the smaller vec while the
+;; other thread increments n past that vec's length.
+;; Note: see comment at test about reliable detection.
+(test-case "sleep-stress: concurrent add (ensure-space! CAS)"
+  (define make-gvector* (es-ns 'make-gvector))
+  (define gvector-add!* (es-ns 'gvector-add!))
+  (define gvector-ref* (es-ns 'gvector-ref))
+  (define gvector-count* (es-ns 'gvector-count))
+  (for ([iter (in-range 5)])
+    (define gv (make-gvector*))
+    ;; Fill to capacity to force resize on next add
+    (for ([i 10])
+      (gvector-add!* gv i))
+    (define pool (make-parallel-thread-pool 2))
+    ;; Use symbols so we can distinguish from garbage memory
+    (define sentinel (gensym 'val))
+    (define t1 (thread #:pool pool (lambda () (gvector-add!* gv sentinel))))
+    (define t2
+      (thread #:pool pool
+              (lambda () (apply gvector-add!* gv (build-list 100 (lambda (_) sentinel))))))
+    (thread-wait t1)
+    (thread-wait t2)
+    (parallel-thread-pool-close pool)
+    ;; Verify invariant by reading every element.
+    ;; With a missing CAS, this may read garbage beyond the vector.
+    ;; However, detection is not guaranteed since the thread creating
+    ;; the larger vector tends to win the vec write.
+    (define count (gvector-count* gv))
+    (for ([i (in-range count)])
+      (define val (gvector-ref* gv i))
+      (check-true (or (fixnum? val) (eq? val sentinel))
+                  (format "iter ~a: garbage at index ~a: ~v" iter i val)))))

--- a/data-test/tests/data/gvector-stress.rkt
+++ b/data-test/tests/data/gvector-stress.rkt
@@ -1,0 +1,280 @@
+#lang racket/base
+(require data/gvector
+         rackunit)
+
+;; Multi-threaded stress tests for gvector memory safety.
+;; Tests both regular threads (concurrent access) and parallel
+;; threads (using #:pool for true parallelism).
+;;
+;; The primary goal is memory safety: no crashes or segfaults.
+;; Count correctness is checked for non-parallel (coroutine) threads
+;; where operations are interleaved but not truly concurrent.
+;; For parallel threads, count may be incorrect due to races on the
+;; n field, but operations must not cause memory-unsafe behavior.
+
+(define ITEMS-PER-THREAD 1000)
+(define NUM-THREADS 8)
+
+;; Test 1: Concurrent adds from multiple coroutine threads
+(test-case "concurrent gvector-add!"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (define threads
+      (for/list ([t (in-range NUM-THREADS)])
+        (thread (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    (for-each thread-wait threads)
+    (check-equal? (gvector-count gv) (* NUM-THREADS ITEMS-PER-THREAD))))
+
+;; Test 2: Parallel adds — tests memory safety, not count correctness
+(test-case "parallel gvector-add!"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (define pool (make-parallel-thread-pool NUM-THREADS))
+    (define threads
+      (for/list ([t (in-range NUM-THREADS)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    (parallel-thread-pool-close pool)
+    (for-each thread-wait threads)
+    ;; Count may be less than expected due to n-field races,
+    ;; but we should not crash
+    (check-true (> (gvector-count gv) 0))))
+
+;; Test 3: Concurrent reads while adding
+(test-case "concurrent add + ref"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (define stop? #f)
+    (define writers
+      (for/list ([t (in-range 4)])
+        (thread (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    ;; Reader threads - should never crash even with stale data
+    (define readers
+      (for/list ([t (in-range 4)])
+        (thread (lambda ()
+                  (let loop ()
+                    (define n (gvector-count gv))
+                    (when (> n 0)
+                      (gvector-ref gv (sub1 n) #f))
+                    (unless stop?
+                      (loop)))))))
+    (for-each thread-wait writers)
+    (set! stop? #t)
+    (for-each thread-wait readers)
+    (check-equal? (gvector-count gv) (* 4 ITEMS-PER-THREAD))))
+
+;; Test 4: Parallel reads while adding — the key memory safety test.
+;; Without vec-before-n ordering, this can segfault when a concurrent
+;; remove shrinks the vector between reading n and reading vec.
+(test-case "parallel add + ref"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (define stop? #f)
+    (define pool (make-parallel-thread-pool 8))
+    (define writers
+      (for/list ([t (in-range 4)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    (define readers
+      (for/list ([t (in-range 4)])
+        (thread #:pool pool
+                (lambda ()
+                  (let loop ()
+                    (define n (gvector-count gv))
+                    (when (> n 0)
+                      (gvector-ref gv (sub1 n) #f))
+                    (unless stop?
+                      (loop)))))))
+    (parallel-thread-pool-close pool)
+    (for-each thread-wait writers)
+    (set! stop? #t)
+    (for-each thread-wait readers)))
+
+;; Test 5: Concurrent iteration while adding
+(test-case "concurrent add + in-gvector"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (define stop? #f)
+    (define writers
+      (for/list ([t (in-range 4)])
+        (thread (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    (define readers
+      (for/list ([t (in-range 4)])
+        (thread (lambda ()
+                  (let loop ()
+                    (for ([x (in-gvector gv)])
+                      (void))
+                    (unless stop?
+                      (loop)))))))
+    (for-each thread-wait writers)
+    (set! stop? #t)
+    (for-each thread-wait readers)))
+
+;; Test 6: Parallel iteration while adding
+(test-case "parallel add + in-gvector"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (define stop? #f)
+    (define pool (make-parallel-thread-pool 8))
+    (define writers
+      (for/list ([t (in-range 4)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    (define readers
+      (for/list ([t (in-range 4)])
+        (thread #:pool pool
+                (lambda ()
+                  (let loop ()
+                    (for ([x (in-gvector gv)])
+                      (void))
+                    (unless stop?
+                      (loop)))))))
+    (parallel-thread-pool-close pool)
+    (for-each thread-wait writers)
+    (set! stop? #t)
+    (for-each thread-wait readers)))
+
+;; Test 7: Concurrent add + remove-last!
+(test-case "concurrent add + remove-last!"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (for ([i (in-range 100)])
+      (gvector-add! gv i))
+    (define writers
+      (for/list ([t (in-range 4)])
+        (thread (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    (define removers
+      (for/list ([t (in-range 2)])
+        (thread (lambda ()
+                  (let loop ([removed 0])
+                    (when (< removed 100)
+                      (with-handlers ([exn:fail? (lambda (e) (loop removed))])
+                        (gvector-remove-last! gv)
+                        (loop (add1 removed)))))))))
+    (for-each thread-wait writers)
+    (for-each thread-wait removers)))
+
+;; Test 8: Parallel add + remove — the key race condition test.
+;; Without vec-before-n ordering in gvector-ref, a remove that shrinks
+;; the backing vector can cause an out-of-bounds unsafe-vector*-ref.
+(test-case "parallel add + remove-last!"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (for ([i (in-range 100)])
+      (gvector-add! gv i))
+    (define pool (make-parallel-thread-pool 6))
+    (define writers
+      (for/list ([t (in-range 4)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-add! gv i))))))
+    (define removers
+      (for/list ([t (in-range 2)])
+        (thread #:pool pool
+                (lambda ()
+                  (let loop ([removed 0])
+                    (when (< removed 100)
+                      (with-handlers ([exn:fail? (lambda (e) (loop removed))])
+                        (gvector-remove-last! gv)
+                        (loop (add1 removed)))))))))
+    (parallel-thread-pool-close pool)
+    (for-each thread-wait writers)
+    (for-each thread-wait removers)))
+
+;; Test 9: Concurrent gvector-set!
+(test-case "concurrent gvector-set!"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (for ([i (in-range 100)])
+      (gvector-add! gv i))
+    (define threads
+      (for/list ([t (in-range NUM-THREADS)])
+        (thread (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-set! gv (modulo i 100) i))))))
+    (for-each thread-wait threads)
+    (check-equal? (gvector-count gv) 100)))
+
+;; Test 10: Parallel gvector-set!
+(test-case "parallel gvector-set!"
+  (for ([_ (in-range 10)])
+    (define gv (make-gvector))
+    (for ([i (in-range 100)])
+      (gvector-add! gv i))
+    (define pool (make-parallel-thread-pool NUM-THREADS))
+    (define threads
+      (for/list ([t (in-range NUM-THREADS)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([i (in-range ITEMS-PER-THREAD)])
+                    (gvector-set! gv (modulo i 100) i))))))
+    (parallel-thread-pool-close pool)
+    (for-each thread-wait threads)
+    (check-equal? (gvector-count gv) 100)))
+
+;; Test 11: for/gvector correctness under concurrency
+(test-case "for/gvector concurrent correctness"
+  (for ([_ (in-range 10)])
+    (define ch (make-channel))
+    (define threads
+      (for/list ([t (in-range NUM-THREADS)])
+        (thread (lambda ()
+                  (define gv (for/gvector ([i (in-range ITEMS-PER-THREAD)]) i))
+                  (channel-put ch gv)))))
+    (for ([_ (in-range NUM-THREADS)])
+      (define gv (channel-get ch))
+      (check-equal? (gvector-count gv) ITEMS-PER-THREAD))))
+
+;; Test 12: Parallel read + remove stress — specifically targets the
+;; vec-before-n ordering bug. Readers continuously read the last element
+;; while removers shrink the vector, which can trigger the race where
+;; n is read before vec, and vec gets replaced with a shorter one.
+;; We fill with many elements then remove most of them to trigger trim!
+;; which replaces vec with a shorter vector.
+(test-case "parallel ref + remove stress"
+  (for ([_ (in-range 50)])
+    (define gv (make-gvector))
+    ;; Fill with enough elements that removing most will trigger trim!
+    ;; trim! fires when cap >= 4*n, so removing 400 of 500 leaves n=100
+    ;; with cap=512 (or similar), triggering shrink to 256, still safe.
+    ;; But if we keep removing down to n=10 with cap=256, trim! shrinks
+    ;; to 128, then 64, etc. During any shrink, the vec is replaced.
+    (for ([i (in-range 1000)])
+      (gvector-add! gv i))
+    (define pool (make-parallel-thread-pool 8))
+    ;; Readers that aggressively read near the end of the gvector
+    (define readers
+      (for/list ([t (in-range 4)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([_ (in-range 50000)])
+                    (define n (gvector-count gv))
+                    (when (> n 0)
+                      ;; Access near the end where trim! is most dangerous
+                      (gvector-ref gv (sub1 n) #f)))))))
+    ;; Removers that aggressively shrink the gvector
+    (define removers
+      (for/list ([t (in-range 4)])
+        (thread #:pool pool
+                (lambda ()
+                  (for ([_ (in-range 200)])
+                    (with-handlers ([exn:fail? void])
+                      (gvector-remove-last! gv)))))))
+    (parallel-thread-pool-close pool)
+    (for-each thread-wait readers)
+    (for-each thread-wait removers)))


### PR DESCRIPTION
* Eliminates contracts in favor of inline checks.
* Specializes multiple-value code to improve
      single-value performance (see racket/racket#4942).
* Use simpler non-recursive growth computation
      (taken from Rust's Vector implementation).
* Avoid duplicate work in core operations.
* Add #:capacity arguments.
* Use unsafe operations.
* Use `vector-extend` from racket/racket#4943.
